### PR TITLE
plugin's json name is unified to

### DIFF
--- a/bin/templates/cordova/Api.js
+++ b/bin/templates/cordova/Api.js
@@ -51,7 +51,7 @@ function setupEvents (externalEventEmitter) {
 
 class Api {
     constructor (platform, platformRootDir, events) {
-        this.platform = 'electron';
+        this.platform = 'cordova-electron';
 
         // MyApp/platforms/electron
         this.root = path.resolve(__dirname, '..');
@@ -330,7 +330,6 @@ class Api {
                 const wwwDest = options.usePlatformWww ?
                     this.getPlatformInfo().locations.platformWww :
                     this.handler.www_dir(this.root);
-
                 if (type === 'asset') {
                     installer.install(item, plugin_dir, wwwDest);
                 } else if (type === 'js-module') {

--- a/bin/templates/cordova/handler.js
+++ b/bin/templates/cordova/handler.js
@@ -63,7 +63,7 @@ module.exports = {
 
             const moduleDestination = path.resolve(www_dir, 'plugins', plugin_id, jsModule.src);
 
-            fs.ensureDirSync('-p', path.dirname(moduleDestination));
+            fs.ensureDirSync(path.dirname(moduleDestination));
             fs.writeFileSync(moduleDestination, scriptContent, 'utf-8');
         },
         uninstall: (jsModule, www_dir, plugin_id) => {


### PR DESCRIPTION
### Platforms affected
cordova-electron

### What does this PR do?

1)
platform name is specified as `cordova-electron` not `electron` in API.js.
Because PlatformJson name is `cordova-electron`.

2)
The parameters of `ensureDirSync` function in handler.js is fixed.


==> Then `cordova plugin add` and `cordova platform rm` works well.

### What testing has been done on this change?

do `cordova plugin add cordova-plugin-camera`.
