### PR TITLE
Fix plugin to use browser settings

### DIFF
--- a/bin/templates/cordova/Api.js
+++ b/bin/templates/cordova/Api.js
@@ -51,7 +51,7 @@ function setupEvents (externalEventEmitter) {
 
 class Api {
     constructor (platform, platformRootDir, events) {
-        this.platform = 'cordova-electron';
+        this.platform = 'electron';
 
         // MyApp/platforms/electron
         this.root = path.resolve(__dirname, '..');

--- a/bin/templates/cordova/Api.js
+++ b/bin/templates/cordova/Api.js
@@ -51,7 +51,7 @@ function setupEvents (externalEventEmitter) {
 
 class Api {
     constructor (platform, platformRootDir, events) {
-        this.platform = 'electron';
+        this.platform = 'cordova-electron';
 
         // MyApp/platforms/electron
         this.root = path.resolve(__dirname, '..');
@@ -330,7 +330,6 @@ class Api {
                 const wwwDest = options.usePlatformWww ?
                     this.getPlatformInfo().locations.platformWww :
                     this.handler.www_dir(this.root);
-
                 if (type === 'asset') {
                     installer.install(item, plugin_dir, wwwDest);
                 } else if (type === 'js-module') {

--- a/bin/templates/cordova/Api.js
+++ b/bin/templates/cordova/Api.js
@@ -243,7 +243,7 @@ class Api {
 
         let platform = this.platform;
         if (! pluginInfo.getPlatformsArray().includes(platform)) { // if `cordova-electron` is not defined in plugin.xml, `browser` is used instead.
-            platform = "browser";
+            platform = 'browser';
         }
 
         // gather all files needs to be handled during install

--- a/bin/templates/cordova/Api.js
+++ b/bin/templates/cordova/Api.js
@@ -241,7 +241,7 @@ class Api {
         const actions = new ActionStack();
         const projectFile = this.handler.parseProjectFile && this.handler.parseProjectFile(this.root);
 
-        var platform = this.platform;
+        let platform = this.platform;
         if (! pluginInfo.getPlatformsArray().includes(platform)) { // if `cordova-electron` is not defined in plugin.xml, `browser` is used instead.
             platform = "browser";
         }

--- a/bin/templates/cordova/Api.js
+++ b/bin/templates/cordova/Api.js
@@ -241,10 +241,15 @@ class Api {
         const actions = new ActionStack();
         const projectFile = this.handler.parseProjectFile && this.handler.parseProjectFile(this.root);
 
+        var platform = this.platform;
+        if (! pluginInfo.getPlatformsArray().includes(platform)) { // if `cordova-electron` is not defined in plugin.xml, `browser` is used instead.
+            platform = "browser";
+        }
+
         // gather all files needs to be handled during install
-        pluginInfo.getFilesAndFrameworks(this.platform)
-            .concat(pluginInfo.getAssets(this.platform))
-            .concat(pluginInfo.getJsModules(this.platform))
+        pluginInfo.getFilesAndFrameworks(platform)
+            .concat(pluginInfo.getAssets(platform))
+            .concat(pluginInfo.getJsModules(platform))
             .forEach((item) => {
                 actions.push(actions.createAction(
                     this._getInstaller(item.itemType),
@@ -254,7 +259,7 @@ class Api {
             });
 
         // run through the action stack
-        return actions.process(this.platform, this.root)
+        return actions.process(platform, this.root)
             .then(() => {
                 if (projectFile) {
                     projectFile.write();
@@ -273,7 +278,7 @@ class Api {
 
                 const targetDir = installOptions.usePlatformWww ? this.getPlatformInfo().locations.platformWww : this.getPlatformInfo().locations.www;
 
-                this._addModulesInfo(pluginInfo, targetDir);
+                this._addModulesInfo(platform, pluginInfo, targetDir);
             });
     }
 
@@ -285,10 +290,15 @@ class Api {
         const actions = new ActionStack();
         const projectFile = this.handler.parseProjectFile && this.handler.parseProjectFile(this.root);
 
+        var platform = this.platform;
+        if (! plugin.getPlatformsArray().includes(platform)) { // if `cordova-electron` is not defined in plugin.xml, `browser` is used instead.
+            platform = "browser";
+        }
+
         // queue up plugin files
-        plugin.getFilesAndFrameworks(this.platform)
-            .concat(plugin.getAssets(this.platform))
-            .concat(plugin.getJsModules(this.platform))
+        plugin.getFilesAndFrameworks(platform)
+            .concat(plugin.getAssets(platform))
+            .concat(plugin.getJsModules(platform))
             .forEach((item) => {
                 actions.push(actions.createAction(
                     this._getUninstaller(item.itemType), [item, plugin.dir, plugin.id, uninstallOptions, projectFile],
@@ -296,7 +306,7 @@ class Api {
             });
 
         // run through the action stack
-        return actions.process(this.platform, this.root)
+        return actions.process(platform, this.root)
             .then(() => {
                 if (projectFile) {
                     projectFile.write();
@@ -372,12 +382,12 @@ class Api {
      * @param   {String}  targetDir  The directory, where updated cordova_plugins.js
      *   should be written to.
      */
-    _addModulesInfo (plugin, targetDir) {
+    _addModulesInfo (platform, plugin, targetDir) {
         let installedModules = this._platformJson.root.modules || [];
 
         const installedPaths = installedModules.map((installedModule) => installedModule.file);
 
-        let modulesToInstall = plugin.getJsModules(this.platform)
+        let modulesToInstall = plugin.getJsModules(platform)
             .filter((moduleToInstall) => installedPaths.indexOf(moduleToInstall.file) === -1)
             .map((moduleToInstall) => {
                 const moduleName = plugin.id + '.' + (moduleToInstall.name || moduleToInstall.src.match(/([^\/]+)\.js/)[1]);

--- a/bin/templates/cordova/Api.js
+++ b/bin/templates/cordova/Api.js
@@ -290,7 +290,7 @@ class Api {
         const actions = new ActionStack();
         const projectFile = this.handler.parseProjectFile && this.handler.parseProjectFile(this.root);
 
-        var platform = this.platform;
+        let platform = this.platform;
         if (! plugin.getPlatformsArray().includes(platform)) { // if `cordova-electron` is not defined in plugin.xml, `browser` is used instead.
             platform = "browser";
         }

--- a/bin/templates/cordova/Api.js
+++ b/bin/templates/cordova/Api.js
@@ -292,7 +292,7 @@ class Api {
 
         let platform = this.platform;
         if (! plugin.getPlatformsArray().includes(platform)) { // if `cordova-electron` is not defined in plugin.xml, `browser` is used instead.
-            platform = "browser";
+            platform = 'browser';
         }
 
         // queue up plugin files

--- a/bin/templates/cordova/handler.js
+++ b/bin/templates/cordova/handler.js
@@ -63,7 +63,7 @@ module.exports = {
 
             const moduleDestination = path.resolve(www_dir, 'plugins', plugin_id, jsModule.src);
 
-            fs.ensureDirSync('-p', path.dirname(moduleDestination));
+            fs.ensureDirSync(path.dirname(moduleDestination));
             fs.writeFileSync(moduleDestination, scriptContent, 'utf-8');
         },
         uninstall: (jsModule, www_dir, plugin_id) => {


### PR DESCRIPTION
### Platforms affected
cordova-electron

### What does this PR do?
If plugin.xml has no `cordova-electron` section, 
use `browser` section instead of `cordova-electron`.

### What testing has been done on this change?

```
cordova plugin add cordova-plugin-camera.
Checking camera plugin works.
```

Note:
In order to work `cordova plugin rm`, we should add `cordova-electron` to 
`cordova-lib/src/platforms/platformsConfig.json` as

```
    "electron": {
        "url": "https://git-wip-us.apache.org/repos/asf?p=cordova-electron.git",
        "version": "~1.0.0",
        "apiCompatibleSince": "1.0.0",
        "deprecated": false
    }
```
(url is dummy)

Please see cordova-lib/src/cordova/platform/addHelper.js where `cordova-electron` is used as `electron`.

