### PR TITLE
cordova-electron is changed to electron in run.js

### DIFF
--- a/bin/templates/cordova/handler.js
+++ b/bin/templates/cordova/handler.js
@@ -63,7 +63,7 @@ module.exports = {
 
             const moduleDestination = path.resolve(www_dir, 'plugins', plugin_id, jsModule.src);
 
-            fs.ensureDirSync('-p', path.dirname(moduleDestination));
+            fs.ensureDirSync(path.dirname(moduleDestination));
             fs.writeFileSync(moduleDestination, scriptContent, 'utf-8');
         },
         uninstall: (jsModule, www_dir, plugin_id) => {

--- a/bin/templates/cordova/lib/run.js
+++ b/bin/templates/cordova/lib/run.js
@@ -24,7 +24,7 @@ const proc = require('child_process');
 
 module.exports.run = (args) => {
     // console.log("runOptions : ", args);
-    const child = proc.spawn(electron, ['./platforms/cordova-electron/main.js']);
+    const child = proc.spawn(electron, ['./platforms/electron/main.js']);
 
     child.on('close', (code) => {
         process.exit(code);


### PR DESCRIPTION


### Platforms affected
cordova-electron

### What does this PR do?
In run.js,

`cordova-electron` => `electron`


### What testing has been done on this change?

no tests

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
