### PR TITLE
change the name cordova-electron to electron

### DIFF
--- a/bin/templates/cordova/Api.js
+++ b/bin/templates/cordova/Api.js
@@ -51,7 +51,7 @@ function setupEvents (externalEventEmitter) {
 
 class Api {
     constructor (platform, platformRootDir, events) {
-        this.platform = 'cordova-electron';
+        this.platform = 'electron';
 
         // MyApp/platforms/electron
         this.root = path.resolve(__dirname, '..');

--- a/bin/templates/cordova/lib/run.js
+++ b/bin/templates/cordova/lib/run.js
@@ -24,7 +24,7 @@ const proc = require('child_process');
 
 module.exports.run = (args) => {
     // console.log("runOptions : ", args);
-    const child = proc.spawn(electron, ['./platforms/cordova-electron/main.js']);
+    const child = proc.spawn(electron, ['./platforms/electron/main.js']);
 
     child.on('close', (code) => {
         process.exit(code);


### PR DESCRIPTION
### Platforms affected

cordova-electron

### What does this PR do?

platform name is changed to `electron` from `cordova-electron` in API.js and run.js

### What testing has been done on this change?


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
