### PR TITLE
fix location of main.js in run.js

### DIFF
--- a/bin/templates/cordova/lib/run.js
+++ b/bin/templates/cordova/lib/run.js
@@ -22,7 +22,7 @@ const proc = require('child_process');
 
 module.exports.run = (args) => {
     // console.log("runOptions : ", args);
-    const child = proc.spawn(electron, ['./platforms/electron/main.js']);
+    const child = proc.spawn(electron, ['./platforms/electron/www/main.js']);
 
     child.on('close', (code) => {
         process.exit(code);


### PR DESCRIPTION

### Platforms affected
cordova-electron

### What does this PR do?
main.js is located under the www.
Therefore `run.js` is changed according to.

### What testing has been done on this change?


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
