### PR TITLE
escape win32 posix path

### DIFF
--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -71,9 +71,9 @@ class ElectronBuilder {
                     throw `The platform "${platform}" contains an invalid property. Valid properties are: package, arch`;
                 } else {
                     userBuildSettings[platform] = [];
-                
+
                     if (!userBuildSettings.config) userBuildSettings.config = {};
-                    
+
                     userBuildSettings.config[platform] = {
                         type: '${BUILD_TYPE}',
                         target: []
@@ -96,7 +96,7 @@ class ElectronBuilder {
                     }
                 }
             }
-            
+
             this.userBuildSettings = userBuildSettings;
         }
 
@@ -126,7 +126,8 @@ class ElectronBuilder {
 
         Object.keys(userConfig).forEach((key) => {
             const regex = new RegExp(`\\$\\{${key}\\}`, 'g');
-            buildSettingsString = buildSettingsString.replace(regex, userConfig[key]);
+            const value = userConfig[key].replace(/\\/g, `\\\\`);
+            buildSettingsString = buildSettingsString.replace(regex, value);
         });
 
         // update build settings with formated data


### PR DESCRIPTION
### Platforms affected
cordova-electron

### What does this PR do?

1. Escape windows path separator `¥¥` to `¥¥¥¥`.
If we does not escape, Json.parse brings error.

### What testing has been done on this change?

Build on local Windows PC.

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
