### PR TITLE
Move dev option to approporiate location

### DIFF
--- a/bin/templates/cordova/lib/SettingJsonParser.js
+++ b/bin/templates/cordova/lib/SettingJsonParser.js
@@ -35,7 +35,7 @@ class SettingJsonParser {
         }
 
         if (config) {
-            this.package.isRelease = (typeof (config.release) !== 'undefined') ? config.release : false;
+            this.package.browserWindow.webPreferences.devTools = !config.release;
         }
 
         return this;

--- a/bin/templates/project/cdv-electron-main.js
+++ b/bin/templates/project/cdv-electron-main.js
@@ -49,7 +49,7 @@ function createWindow () {
     });
 
     // Open the DevTools.
-    if (!cdvElectronSettings.isRelease) {
+    if (!cdvElectronSettings.browserWindow.webPreferences.devTools) {
         mainWindow.webContents.openDevTools();
     }
 

--- a/bin/templates/project/cdv-electron-settings.json
+++ b/bin/templates/project/cdv-electron-settings.json
@@ -1,11 +1,9 @@
 {
-    "isRelease": false,
     "browserWindow": {
-        "devTools": false,
+        "webPreferences":{
+            "devTools": true
+        },
         "width": 800,
-        "height": 600,
-        "webPreferences": {
-            "nodeIntegration": false
-        }
+        "height": 600
     }
 }

--- a/tests/spec/unit/templates/cordova/lib/SettingJsonParser.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/SettingJsonParser.spec.js
@@ -67,92 +67,96 @@ describe('Testing SettingJsonParser.js:', () => {
             expect(settingJsonParser.package).toEqual({});
         });
 
-        it('should be equal to undefined, when config file is undefined.', () => {
-            // mock options data
-            options = { options: { argv: [] } };
-
-            settingJsonParser = new SettingJsonParser(locations.www).configure(undefined);
-
-            expect(requireSpy).toHaveBeenCalled();
-            expect(settingJsonParser.package.isRelease).toEqual(undefined);
-        });
-
-        it('should be equal to false, when no flag is set.', () => {
-            // mock options data
-            options = { options: { argv: [] } };
-
-            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options);
-
-            expect(requireSpy).toHaveBeenCalled();
-            expect(settingJsonParser.package.isRelease).toEqual(false);
-        });
-
-        it('should be equal to false, when debug flag is set.', () => {
-            // mock options data
-            options = { options: { debug: true, argv: [] } };
-
-            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options);
-
-            expect(requireSpy).toHaveBeenCalled();
-            expect(settingJsonParser.package.isRelease).toEqual(false);
-        });
-
-        it('should be equal to true, when release flag is set.', () => {
-            // mock options data
+        it('should use default when users settings files does not exist, but set devTools value from options', () => {
             options = { options: { release: true, argv: [] } };
 
-            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options);
+            SettingJsonParser.__set__('require', (file) => {
+                // return defaults
+                if (file.includes('cdv-electron-settings.json')) {
+                    return {
+                        browserWindow: {
+                            webPreferences: {
+                                devTools: true,
+                                nodeIntegration: true
+                            }
+                        }
+                    };
+                }
 
-            expect(requireSpy).toHaveBeenCalled();
-            expect(settingJsonParser.package.isRelease).toEqual(true);
+                return require(file);
+            });
+
+            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options, false);
+
+            expect(settingJsonParser.package.browserWindow.webPreferences.devTools).toBe(false);
+            expect(settingJsonParser.package.browserWindow.webPreferences.nodeIntegration).toBe(true);
         });
 
-        it('should write provided data, when no flag is set.', () => {
-            let writeFileSyncSpy;
-            writeFileSyncSpy = jasmine.createSpy('writeFileSync');
-            settingJsonParser.__set__('fs', { writeFileSync: writeFileSyncSpy });
+        it('should use default when users settings files does not exist.', () => {
+            options = {};
 
-            options = { options: { argv: [] } };
+            SettingJsonParser.__set__('require', (file) => {
+                // return defaults
+                if (file.includes('cdv-electron-settings.json')) {
+                    return {
+                        browserWindow: {
+                            webPreferences: {
+                                devTools: true,
+                                nodeIntegration: true
+                            }
+                        }
+                    };
+                }
 
-            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options).write();
+                return require(file);
+            });
 
-            expect(writeFileSyncSpy).toHaveBeenCalled();
+            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options, false);
 
-            const settingsPath = writeFileSyncSpy.calls.argsFor(0)[0];
-            expect(settingsPath).toEqual(path.join('mock', 'www', 'cdv-electron-settings.json'));
-
-            // get settings json file content and remove white spaces
-            let settingsFile = writeFileSyncSpy.calls.argsFor(0)[1];
-            settingsFile = settingsFile.replace(/\s+/g, '');
-            expect(settingsFile).toEqual('{"isRelease":false}');
-
-            const settingsFormat = writeFileSyncSpy.calls.argsFor(0)[2];
-            expect(settingsFormat).toEqual('utf8');
+            expect(settingJsonParser.package.browserWindow.webPreferences.devTools).toBe(true);
+            expect(settingJsonParser.package.browserWindow.webPreferences.nodeIntegration).toBe(true);
         });
 
-        it('should write provided data, when debug flag is set.', () => {
-            const writeFileSyncSpy = jasmine.createSpy('writeFileSync');
-            settingJsonParser.__set__('fs', { writeFileSync: writeFileSyncSpy });
-
+        it('should load users override settings and merge on default, but set devTools value from options.', () => {
             options = { options: { debug: true, argv: [] } };
 
-            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options).write();
+            SettingJsonParser.__set__('require', (file) => {
+                if (file === 'LOAD_MY_FAKE_DATA') {
+                    return {
+                        browserWindow: {
+                            webPreferences: {
+                                devTools: false,
+                                nodeIntegration: false
+                            }
+                        }
+                    };
+                }
 
-            expect(writeFileSyncSpy).toHaveBeenCalled();
+                // return defaults
+                if (file.includes('cdv-electron-settings.json')) {
+                    return {
+                        browserWindow: {
+                            webPreferences: {
+                                devTools: true,
+                                nodeIntegration: true
+                            }
+                        }
+                    };
+                }
 
-            const settingsPath = writeFileSyncSpy.calls.argsFor(0)[0];
-            expect(settingsPath).toEqual(path.join('mock', 'www', 'cdv-electron-settings.json'));
+                return require(file);
+            });
 
-            // get settings json file content and remove white spaces
-            let settingsFile = writeFileSyncSpy.calls.argsFor(0)[1];
-            settingsFile = settingsFile.replace(/\s+/g, '');
-            expect(settingsFile).toEqual('{"isRelease":false}');
+            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options, 'LOAD_MY_FAKE_DATA');
 
-            const settingsFormat = writeFileSyncSpy.calls.argsFor(0)[2];
-            expect(settingsFormat).toEqual('utf8');
+            expect(settingJsonParser.package.browserWindow.webPreferences.devTools).toBe(true);
+            expect(settingJsonParser.package.browserWindow.webPreferences.nodeIntegration).toBe(false);
+
         });
 
-        it('should load users blank settings and merge on default.', () => {
+        it('should write provided data.', () => {
+            const writeFileSyncSpy = jasmine.createSpy('writeFileSync');
+            settingJsonParser.__set__('fs', { writeFileSync: writeFileSyncSpy });
             options = { options: { debug: true, argv: [] } };
 
             SettingJsonParser.__set__('require', (file) => {
@@ -161,9 +165,11 @@ describe('Testing SettingJsonParser.js:', () => {
                 // return defaults
                 if (file.includes('cdv-electron-settings.json')) {
                     return {
-                        isRelease: false,
-                        webPreferences: {
-                            nodeIntegration: true
+                        browserWindow: {
+                            webPreferences: {
+                                devTools: true,
+                                nodeIntegration: true
+                            }
                         }
                     };
                 }
@@ -171,58 +177,14 @@ describe('Testing SettingJsonParser.js:', () => {
                 return require(file);
             });
 
-            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options, 'LOAD_MY_FAKE_DATA');
-
-            expect(settingJsonParser.package.webPreferences.nodeIntegration).toBe(true);
-        });
-
-        it('should load users override settings and merge on default.', () => {
-            options = { options: { debug: true, argv: [] } };
-
-            SettingJsonParser.__set__('require', (file) => {
-                if (file === 'LOAD_MY_FAKE_DATA') {
-                    return {
-                        webPreferences: {
-                            nodeIntegration: false
-                        }
-                    };
-                }
-
-                // return defaults
-                if (file.includes('cdv-electron-settings.json')) {
-                    return {
-                        isRelease: false,
-                        webPreferences: {
-                            nodeIntegration: true
-                        }
-                    };
-                }
-
-                return require(file);
-            });
-
-            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options, 'LOAD_MY_FAKE_DATA');
-
-            expect(settingJsonParser.package.webPreferences.nodeIntegration).toBe(false);
-        });
-
-        it('should write provided data.', () => {
-            const writeFileSyncSpy = jasmine.createSpy('writeFileSync');
-            settingJsonParser.__set__('fs', { writeFileSync: writeFileSyncSpy });
-
-            options = { options: { release: true, argv: [] } };
-
-            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options).write();
+            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options, 'LOAD_MY_FAKE_DATA').write();
 
             expect(writeFileSyncSpy).toHaveBeenCalled();
-
-            const settingsPath = writeFileSyncSpy.calls.argsFor(0)[0];
-            expect(settingsPath).toEqual(path.join('mock', 'www', 'cdv-electron-settings.json'));
 
             // get settings json file content and remove white spaces
             let settingsFile = writeFileSyncSpy.calls.argsFor(0)[1];
             settingsFile = settingsFile.replace(/\s+/g, '');
-            expect(settingsFile).toEqual('{"isRelease":true}');
+            expect(settingsFile).toEqual(`{"browserWindow":{"webPreferences":{"devTools":true,"nodeIntegration":true}}}`);
 
             const settingsFormat = writeFileSyncSpy.calls.argsFor(0)[2];
             expect(settingsFormat).toEqual('utf8');


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

electron

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

devTools option can be set inside `webPreferences`. Therefore, we can delete`isRelease` option and set `devTools` option inside  `webPreferences` instead.

### Description
<!-- Describe your changes in detail -->

- Move dev option to the appropriate location.
- Update tests.

### Testing
<!-- Please describe in detail how you tested your changes. -->

`npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
